### PR TITLE
Add workflow for launcher

### DIFF
--- a/.github/workflows/build_prod.yml
+++ b/.github/workflows/build_prod.yml
@@ -43,6 +43,23 @@ jobs:
               with:
                   name: payload-elf
                   path: ./payload/build
+    launcher: 
+        name: Launcher
+        runs-on: ubuntu-latest
+        container: devkitpro/devkitppc:latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Build Launcher
+              run: |
+                cd ./launcher
+                make
+                cd ..
+            - name: Upload Launcher
+              uses: actions/upload-artifact@v4.0.0
+              with:
+                  name: launcher
+                  path: ./launcher/launcher.dol
+        
     stage1:
         name: Stage 1 and 0
         runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a workflow for the prod build of the standalone launcher.
I didn't see any code that accounts for a debug build, which explains why it is only in the prod workflow.